### PR TITLE
Downgrade pyside6 version requirement to 6.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Ynput's fork of Nodz"
 requires-python = ">=3.9"
 dependencies = [
     "qtpy",
-    "PySide6 >=6.7.1"
+    "PySide6 ==6.7.1"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Ynput's fork of Nodz"
 requires-python = ">=3.9"
 dependencies = [
     "qtpy",
-    "PySide6"
+    "PySide6 >=6.7.1"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Changelog Description
Keep PySide6 requirements in sync with rest of the AYON eco-system, so `Nodz` can be installed through `ayon_workflow`.
I believe this is dragged from: https://github.com/ynput/ayon-launcher/blob/develop/pyproject.toml#L94

## Additional review information
I tried `PySide6 >=6.7.1` which did not work.

## Testing notes:
1. https://github.com/ynput/ayon-workflow/pull/10
2. Create a package from `ayon_workflow` and uplod to server then add to a dev or prod bundle
3. Update global dependencies for bundle through `ayon-dependencies-tool`
4. Ensure `ayon_workflow` and `nodz` are properly part of the resulting env.
