### PR TITLE
Introduce ItemFactory and data models for NodeItem, SlotItem, etc.

### DIFF
--- a/nodz/data_types.py
+++ b/nodz/data_types.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass, field, fields, asdict
+from typing import Tuple
+from qtpy import QtCore
+
+# =============================================================================
+# Data Models
+# =============================================================================
+
+
+@dataclass
+class BaseModel:
+    """Common additional methods for all models."""
+
+    def to_dict(self):
+        return asdict(self)
+
+
+@dataclass
+class AttrModel(BaseModel):
+    """Serializable data model for a node attribute."""
+    attribute: str
+    index: int
+    preset: str
+    plug: bool
+    socket: bool
+    data_type: str
+    plug_max_connections: int
+    socket_max_connections: int
+    kwargs: dict = field(default_factory=dict)
+
+
+@dataclass
+class NodeModel(BaseModel):
+    """Serializable data model for a node."""
+    name: str
+    alternate: bool
+    preset: str
+    position: QtCore.QPointF = field(
+        default_factory=lambda: QtCore.QPointF(-1.0, -1.0)
+    )
+    attributes: list[AttrModel] = field(default_factory=list)
+    kwargs: dict = field(default_factory=dict)
+
+    def valid_position(self):
+        return self.position.x() >= 0.0 and self.position.y() >= 0.0
+
+
+@dataclass
+class ConnectionModel(BaseModel):
+    """Serializable data model for a connection."""
+    plug_node: str = ""
+    plug_attr: str = ""
+    socket_node: str = ""
+    socket_attr: str = ""
+    kwargs: dict = field(default_factory=dict)

--- a/nodz/items.py
+++ b/nodz/items.py
@@ -514,6 +514,7 @@ class SlotItem(QtWidgets.QGraphicsItem):
         self.setAcceptHoverEvents(True)
 
         # Storage.
+        self.max_connections = 0
         self.slot_type = SlotItem.Type.Slot
 
         # Style.
@@ -527,13 +528,6 @@ class SlotItem(QtWidgets.QGraphicsItem):
         self.connected_slots = list()
         self.new_connection = None
         self.connections = list()
-        self.max_connections = (
-            model.plug_max_connections
-            if model.plug
-            else model.socket_max_connections
-            if model.socket
-            else 0
-        )
 
     def to_dict(self) -> dict:
         """
@@ -768,6 +762,7 @@ class PlugItem(SlotItem):
         )
 
         # Storage.
+        self.max_connections = model.plug_max_connections
         self.slot_type = SlotItem.Type.Plug
 
         # Methods.
@@ -885,6 +880,7 @@ class SocketItem(SlotItem):
         )
 
         # Storage.
+        self.max_connections = model.socket_max_connections
         self.slot_type = SlotItem.Type.Socket
 
         # Methods.

--- a/nodz/items.py
+++ b/nodz/items.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-from typing import Any, Generator, Optional
+from enum import Enum
+from typing import Any, Tuple, Optional, Union
 from qtpy import QtGui, QtCore, QtWidgets
-import nodz.utils as utils
-from nodz.utils import nlog
+from .utils import _convert_data_to_color, _create_pointer_bounding_box
+from .data_types import NodeModel, AttrModel, ConnectionModel
 
 
 class NodeItem(QtWidgets.QGraphicsItem):
@@ -10,18 +11,14 @@ class NodeItem(QtWidgets.QGraphicsItem):
     A graphic representation of a node containing attributes.
     """
 
-    def __init__(
-        self, name: str, alternate: bool, preset: str, config: dict
-    ) -> None:
+    def __init__(self, model: NodeModel, config: dict) -> None:
         """
         Initialize the class.
 
         Args:
             name (str): The name of the node. The name has to be unique as it
                 is used as a key to store the node object.
-            alternate (bool): Whether the node uses the alternating style for
-                attributes or not.
-            preset (str): color preset to use for the node.
+            model (NodeModel): Serializable description of the node.
             config (dict): Configuration dictionary for the node.
         """
         super(NodeItem, self).__init__()
@@ -29,17 +26,10 @@ class NodeItem(QtWidgets.QGraphicsItem):
         self.setZValue(1)
 
         # Storage
-        self.name = name
-        self.alternate = alternate
-        self.node_preset = preset
-        self.attr_preset = None
+        self.model = model
         self.config = config
 
         # Attributes storage.
-        self.attrs = list()
-        self.attrs_data = dict()  # used to draw the attributes
-        self.attr_count = 0
-
         self.plugs = dict()
         self.sockets = dict()
         self.unconnectables = dict()
@@ -49,44 +39,26 @@ class NodeItem(QtWidgets.QGraphicsItem):
         # Methods.
         self._create_style()
 
-    def _attr_iter(self, attr: str) -> Generator[SlotItem]:
-        """
-        Iterate over valid a specific attribute's items. This is used for
-        serialization.
-        """
-        for inst in (
-            self.plugs.get(attr),
-            self.sockets.get(attr),
-            self.unconnectables.get(attr),
-        ):
-            if inst:
-                yield inst
+    @property
+    def attrs(self) -> list[str]:
+        """Returns a list of attribute names, based on the node's model."""
+        return [am.attribute for am in self.model.attributes]
 
-    def _attr_to_dict(self, attr: str) -> dict:
-        """
-        Serialize an existing attribute to a dict.
+    @property
+    def attr_count(self) -> int:
+        """Returns the number of attributes, based on the node's model."""
+        return len(self.model.attributes)
 
-        Args:
-            attr (str): Attribute name.
-        """
-        at = dict()
-        for inst in self._attr_iter(attr):
-            at.update(inst.to_dict())
-        return at
+    @property
+    def attrs_data(self) -> dict[str, AttrModel]:
+        """Returns a dictionary of attribute names and their models."""
+        return {m.attribute: m for m in self.model.attributes}
 
     def to_dict(self) -> dict:
         """
-        Serialize the NodeItem to a dict.
+        Serialize the NodeItem's model to a dict.
         """
-        n = {
-            "alternate": self.alternate,
-            "preset": self.node_preset,
-            "position": self.scenePos().toTuple(),
-            "attributes": [],
-        }
-        for attr in self.attrs:
-            n["attributes"].append(self._attr_to_dict(attr))
-        return n
+        return self.model.to_dict()
 
     @property
     def height(self) -> int:
@@ -140,29 +112,27 @@ class NodeItem(QtWidgets.QGraphicsItem):
         self._brush = QtGui.QBrush()
         self._brush.setStyle(QtCore.Qt.BrushStyle.SolidPattern)
         self._brush.setColor(
-            utils._convert_data_to_color(config[self.node_preset]["bg"])
+            _convert_data_to_color(config[self.model.preset]["bg"])
         )
 
         self._pen = QtGui.QPen()
         self._pen.setStyle(QtCore.Qt.PenStyle.SolidLine)
         self._pen.setWidth(self.border)
         self._pen.setColor(
-            utils._convert_data_to_color(config[self.node_preset]["border"])
+            _convert_data_to_color(config[self.model.preset]["border"])
         )
 
         self._pen_sel = QtGui.QPen()
         self._pen_sel.setStyle(QtCore.Qt.PenStyle.SolidLine)
         self._pen_sel.setWidth(self.border)
         self._pen_sel.setColor(
-            utils._convert_data_to_color(
-                config[self.node_preset]["border_sel"]
-            )
+            _convert_data_to_color(config[self.model.preset]["border_sel"])
         )
 
         self._text_pen = QtGui.QPen()
         self._text_pen.setStyle(QtCore.Qt.PenStyle.SolidLine)
         self._text_pen.setColor(
-            utils._convert_data_to_color(config[self.node_preset]["text"])
+            _convert_data_to_color(config[self.model.preset]["text"])
         )
 
         self._node_text_font = QtGui.QFont(
@@ -195,8 +165,8 @@ class NodeItem(QtWidgets.QGraphicsItem):
         data_type: Any,
         plug_max_connections: int,
         socket_max_connections: int,
-        attr_config_data: dict | None = None,
-    ) -> None:
+        **kwargs,
+    ) -> int:
         """
         Create an attribute by expanding the node, adding a label and
         connection items.
@@ -210,66 +180,63 @@ class NodeItem(QtWidgets.QGraphicsItem):
             data_type (Any): The data type of the attribute.
             plug_max_connections(int): The plug's maximum number of connections.
             socket_max_connections(int): The socket's maximum number of connections.
+            kwargs: Additional keyword arguments.
+        Returns:
+            int: The actual attribute index.
         """
         if name in self.attrs:
-            nlog.error(
+            raise NameError(
                 "An attribute with the same name already exists on this "
                 f"node : {name}"
             )
-            nlog.error("Attribute creation aborted !")
-            return
 
-        self.attr_preset = preset
+        factory = scene_factory(self)
+
+        attr_model = AttrModel(
+            name,
+            index,
+            preset,
+            plug,
+            socket,
+            data_type,
+            plug_max_connections,
+            socket_max_connections,
+            kwargs=kwargs,
+        )
 
         # Create a plug connection item.
         if plug:
-            plug_inst = PlugItem(
-                self,
-                name,
-                self.attr_count,
-                preset,
-                data_type,
-                plug_max_connections,
-                self.config,
-            )
+            plug_inst = factory.create_plug(self, attr_model, self.config)
             self.plugs[name] = plug_inst
 
         # Create a socket connection item.
         if socket:
-            socket_inst = SocketItem(
-                self,
-                name,
-                self.attr_count,
-                preset,
-                data_type,
-                socket_max_connections,
-                self.config,
-            )
+            socket_inst = factory.create_socket(self, attr_model, self.config)
             self.sockets[name] = socket_inst
 
+        # Unconnectable slot that still needs to be serialized.
         if not plug and not socket:
-            unconnectable_inst = SlotItem(
-                None, name, preset, self.attr_count, data_type, 0, self.config
+            unconnectable_inst = factory.create_slot(
+                None, attr_model, self.config
             )
             self.unconnectables[name] = unconnectable_inst
 
-        self.attr_count += 1
-
-        # Add the attribute based on its index.
+        # Add the attribute based on its index and update model index.
         if index == -1 or index > self.attr_count:
-            self.attrs.append(name)
+            attr_model.index = len(self.model.attributes)
+            self.model.attributes.append(attr_model)
         else:
-            self.attrs.insert(index, name)
-
-        # Store attr data.
-        self.attrs_data[name] = self._attr_to_dict(name)
+            attr_model.index = index
+            self.model.attributes.insert(index, attr_model)
 
         # Update node height.
         self.update()
 
+        return attr_model.index
+
     def _delete_attribute(self, index: int) -> None:
         """
-        Remove an attribute by reducing the node, removing the label
+        Remove an attribute by reducing the node's height, removing the label
         and the connection items.
 
         Args:
@@ -293,13 +260,8 @@ class NodeItem(QtWidgets.QGraphicsItem):
             self.scene().removeItem(self.plugs[name])
             self.plugs.pop(name)
 
-        # Reduce node height.
-        if self.attr_count > 0:
-            self.attr_count -= 1
-
         # Remove attribute from node.
-        if name in self.attrs:
-            self.attrs.remove(name)
+        self.model.attributes.pop(index)
 
         self.update()
 
@@ -352,14 +314,14 @@ class NodeItem(QtWidgets.QGraphicsItem):
         painter.setFont(self._node_text_font)
 
         metrics = painter.fontMetrics()
-        text_width = metrics.boundingRect(self.name).width() + 14
-        text_height = metrics.boundingRect(self.name).height() + 14
+        text_width = metrics.boundingRect(self.model.name).width() + 14
+        text_height = metrics.boundingRect(self.model.name).height() + 14
         margin = (text_width - self.base_width) * 0.5
         text_rect = QtCore.QRect(
             -margin, -text_height, text_width, text_height
         )
 
-        painter.drawText(text_rect, align_flag, self.name)
+        painter.drawText(text_rect, align_flag, self.model.name)
 
     def paint_attr_base(
         self,
@@ -370,20 +332,18 @@ class NodeItem(QtWidgets.QGraphicsItem):
     ):
         config = self.config
         attr_data = self.attrs_data[attr]
-        preset = attr_data["preset"]
+        preset = attr_data.preset
 
         # Attribute base.
-        self._attr_brush.setColor(
-            utils._convert_data_to_color(config[preset]["bg"])
-        )
-        if self.alternate:
+        self._attr_brush.setColor(_convert_data_to_color(config[preset]["bg"]))
+        if self.model.alternate:
             self._attr_brush_alt.setColor(
-                utils._convert_data_to_color(
+                _convert_data_to_color(
                     config[preset]["bg"], True, config["alternate_value"]
                 )
             )
 
-        self._attr_pen.setColor(utils._convert_data_to_color([0, 0, 0, 0]))
+        self._attr_pen.setColor(_convert_data_to_color([0, 0, 0, 0]))
         painter.setPen(self._attr_pen)
         painter.setBrush(self._attr_brush)
         if (offset / self.attr_height) % 2:
@@ -400,9 +360,9 @@ class NodeItem(QtWidgets.QGraphicsItem):
     ):
         config = self.config
         attr_data = self.attrs_data[attr]
-        preset = attr_data["preset"]
+        preset = attr_data.preset
 
-        painter.setPen(utils._convert_data_to_color(config[preset]["text"]))
+        painter.setPen(_convert_data_to_color(config[preset]["text"]))
         painter.setFont(self._attr_text_font)
 
         # Search non-connectable attributes.
@@ -410,17 +370,19 @@ class NodeItem(QtWidgets.QGraphicsItem):
             if self == SlotItem.current_hovered_node:
                 if not SlotItem.source_slot:
                     raise TypeError("Invalid source_slot")
-                if attr_data["dataType"] != SlotItem.source_slot.data_type or (
-                    SlotItem.source_slot.slot_type == "plug"
-                    and attr_data["socket"] is False
-                    or SlotItem.source_slot.slot_type == "socket"
-                    and attr_data["plug"] is False
+                if (
+                    attr_data.data_type != SlotItem.source_slot.model.data_type
+                    or (
+                        SlotItem.source_slot.slot_type == SlotItem.Type.Plug
+                        and attr_data.socket is False
+                        or SlotItem.source_slot.slot_type
+                        == SlotItem.Type.Socket
+                        and attr_data.plug is False
+                    )
                 ):
                     # Set non-connectable attributes color.
                     painter.setPen(
-                        utils._convert_data_to_color(
-                            config["non_connectable_color"]
-                        )
+                        _convert_data_to_color(config["non_connectable_color"])
                     )
 
         text_rect = QtCore.QRect(
@@ -477,7 +439,7 @@ class NodeItem(QtWidgets.QGraphicsItem):
         Emit a signal when the node is double-clicked.
         """
         super(NodeItem, self).mouseDoubleClickEvent(event)
-        self.scene().signal_NodeDoubleClicked.emit(self.name)
+        self.scene().signal_NodeDoubleClicked.emit(self.model)  # type: ignore
 
     def mouseMoveEvent(
         self, event: QtWidgets.QGraphicsSceneMouseEvent
@@ -495,7 +457,7 @@ class NodeItem(QtWidgets.QGraphicsItem):
         # Emit node moved signal.
         if self._moving:
             self._moving = False
-            self.scene().signal_NodeMoved.emit(self.name, self.pos())
+            self.scene().signal_NodeMoved.emit(self.model, self.pos())  # type: ignore
         super(NodeItem, self).mouseReleaseEvent(event)
 
     def hoverLeaveEvent(
@@ -521,14 +483,15 @@ class SlotItem(QtWidgets.QGraphicsItem):
     current_hovered_node: Optional[NodeItem] = None
     source_slot: Optional[SlotItem] = None
 
+    class Type(Enum):
+        Slot = 0
+        Plug = 1
+        Socket = 2
+
     def __init__(
         self,
         parent: QtWidgets.QGraphicsItem | None,
-        attribute: str,
-        preset: str,
-        index: int,
-        data_type: Any,
-        max_connections: int,
+        model: AttrModel,
         config: dict,
     ) -> None:
         """
@@ -544,17 +507,14 @@ class SlotItem(QtWidgets.QGraphicsItem):
                 the slot.
         """
         super(SlotItem, self).__init__(parent)
+        self.model = model
         self.config = config
 
         # Status.
         self.setAcceptHoverEvents(True)
 
         # Storage.
-        self.slot_type = None
-        self.attribute = attribute
-        self.preset = preset
-        self.index = index
-        self.data_type = data_type
+        self.slot_type = SlotItem.Type.Slot
 
         # Style.
         self.brush = QtGui.QBrush()
@@ -567,22 +527,19 @@ class SlotItem(QtWidgets.QGraphicsItem):
         self.connected_slots = list()
         self.new_connection = None
         self.connections = list()
-        self.max_connections = max_connections
+        self.max_connections = (
+            model.plug_max_connections
+            if model.plug
+            else model.socket_max_connections
+            if model.socket
+            else 0
+        )
 
     def to_dict(self) -> dict:
         """
         Serialize the slot item to a dict.
         """
-        return {
-            "name": self.attribute,
-            "preset": self.preset,
-            "index": self.index,
-            "dataType": str(self.data_type),
-            "socket": False,
-            "socketMaxConnections": 0,
-            "plug": False,
-            "plugMaxConnections": 0,
-        }
+        return self.model.to_dict()
 
     def parent_node_item(self) -> NodeItem:
         item = self.parentItem()
@@ -626,7 +583,7 @@ class SlotItem(QtWidgets.QGraphicsItem):
             return False
 
         # no connection with different types
-        if slot_item.data_type != self.data_type:
+        if slot_item.model.data_type != self.model.data_type:
             return False
 
         # otherwize, all fine.
@@ -639,7 +596,8 @@ class SlotItem(QtWidgets.QGraphicsItem):
         Start the connection process.
         """
         if event.button() == QtCore.Qt.MouseButton.LeftButton:
-            self.new_connection = ConnectionItem(
+            factory = scene_factory(self)
+            self.new_connection = factory.create_connection(
                 self.center().toPoint(),
                 self.mapToScene(event.pos()).toPoint(),
                 self,
@@ -662,7 +620,7 @@ class SlotItem(QtWidgets.QGraphicsItem):
         """
         config = self.config
         if SlotItem.drawing_connection:
-            mbb = utils._create_pointer_bounding_box(
+            mbb = _create_pointer_bounding_box(
                 pointer_pos=event.scenePos().toPoint(),
                 bb_size=config["mouse_bounding_box"],
             )
@@ -754,20 +712,17 @@ class SlotItem(QtWidgets.QGraphicsItem):
         if SlotItem.drawing_connection:
             if self.parentItem() == SlotItem.current_hovered_node:
                 painter.setBrush(
-                    utils._convert_data_to_color(
-                        config["non_connectable_color"]
-                    )
+                    _convert_data_to_color(config["non_connectable_color"])
                 )
                 if not SlotItem.source_slot:
                     raise TypeError("Invalid source_slot")
                 if self.slot_type == SlotItem.source_slot.slot_type or (
                     self.slot_type != SlotItem.source_slot.slot_type
-                    and self.data_type != SlotItem.source_slot.data_type
+                    and self.model.data_type
+                    != SlotItem.source_slot.model.data_type
                 ):
                     painter.setBrush(
-                        utils._convert_data_to_color(
-                            config["non_connectable_color"]
-                        )
+                        _convert_data_to_color(config["non_connectable_color"])
                     )
                 else:
                     _pen_valid = QtGui.QPen()
@@ -783,12 +738,7 @@ class SlotItem(QtWidgets.QGraphicsItem):
         """
         Return The center of the Slot.
         """
-        rect = self.boundingRect()
-        center = QtCore.QPointF(
-            rect.x() + rect.width() * 0.5, rect.y() + rect.height() * 0.5
-        )
-
-        return self.mapToScene(center)
+        return self.mapToScene(self.boundingRect().center())
 
 
 class PlugItem(SlotItem):
@@ -800,11 +750,7 @@ class PlugItem(SlotItem):
     def __init__(
         self,
         parent: QtWidgets.QGraphicsItem,
-        attribute: str,
-        index: int,
-        preset: str,
-        data_type: Any,
-        max_connections: int,
+        model: AttrModel,
         config: dict,
     ) -> None:
         """
@@ -812,40 +758,22 @@ class PlugItem(SlotItem):
 
         Args:
             parent (QtWidgets.QGraphicsItem): The parent item of the plug.
-            attribute (str): The attribute name of the plug.
-            index (int): The index of the plug in the parent's list of slots.
-            preset (str): The preset value of the plug.
-            data_type (Any): The data type of the plug.
-            max_connections (int): The maximum number of connections allowed for
-                the plug.
+            model (AttrModel): The description of the attribute.
+            config (dict): The configuration of the scene.
         """
         super(PlugItem, self).__init__(
             parent,
-            attribute,
-            preset,
-            index,
-            data_type,
-            max_connections,
+            model,
             config,
         )
 
         # Storage.
-        self.attributte = attribute
-        self.preset = preset
-        self.slot_type = "plug"
+        self.slot_type = SlotItem.Type.Plug
 
         # Methods.
-        self._create_style(parent)
+        self._create_style()
 
-    def to_dict(self) -> dict:
-        """
-        Serialize the plug item to a dict.
-        """
-        d = dict(super().to_dict())
-        d.update({"plug": True, "plugMaxConnections": self.max_connections})
-        return d
-
-    def _create_style(self, parent: QtWidgets.QGraphicsItem) -> None:
+    def _create_style(self) -> None:
         """
         Read the attribute style from the configuration file.
 
@@ -856,7 +784,7 @@ class PlugItem(SlotItem):
         self.brush = QtGui.QBrush()
         self.brush.setStyle(QtCore.Qt.BrushStyle.SolidPattern)
         self.brush.setColor(
-            utils._convert_data_to_color(config[self.preset]["plug"])
+            _convert_data_to_color(config[self.model.preset]["plug"])
         )
 
     def boundingRect(self) -> QtCore.QRectF:
@@ -874,7 +802,7 @@ class PlugItem(SlotItem):
             self.parent_node_item().base_height
             - config["node_radius"]
             + self.parent_node_item().attr_height / 4
-            + self.parent_node_item().attrs.index(self.attribute)
+            + self.parent_node_item().attrs.index(self.model.attribute)
             * self.parent_node_item().attr_height
         )
 
@@ -898,8 +826,8 @@ class PlugItem(SlotItem):
 
         # Populate connection.
         connection.socket_item = item
-        connection.plug_node = self.parent_node_item().name
-        connection.plug_attr = self.attribute
+        connection.model.plug_node = self.parent_node_item().model.name
+        connection.model.plug_attr = self.model.attribute
 
         # Add socket to connected slots.
         if item in self.connected_slots:
@@ -911,12 +839,7 @@ class PlugItem(SlotItem):
             self.connections.append(connection)
 
         # Emit signal.
-        self.scene().signal_PlugConnected.emit(
-            connection.plug_node,
-            connection.plug_attr,
-            connection.socket_node,
-            connection.socket_attr,
-        )
+        self.scene().signal_PlugConnected.emit(connection.model)  # type: ignore
 
     def disconnect(self, connection: ConnectionItem) -> None:
         """
@@ -926,12 +849,7 @@ class PlugItem(SlotItem):
             connection (ConnectionItem): The connection to disconnect.
         """
         # Emit signal.
-        self.scene().signal_PlugDisconnected.emit(
-            connection.plug_node,
-            connection.plug_attr,
-            connection.socket_node,
-            connection.socket_attr,
-        )
+        self.scene().signal_PlugDisconnected.emit(connection.model)  # type: ignore
 
         # Remove connected socket from plug
         if connection.socket_item in self.connected_slots:
@@ -949,11 +867,7 @@ class SocketItem(SlotItem):
     def __init__(
         self,
         parent: QtWidgets.QGraphicsItem,
-        attribute: str,
-        index: int,
-        preset: str,
-        data_type: Any,
-        max_connections: int,
+        model: AttrModel,
         config: dict,
     ) -> None:
         """
@@ -961,42 +875,22 @@ class SocketItem(SlotItem):
 
         Args:
             parent (QtWidgets.QGraphicsItem): The parent item of the socket.
-            attribute (str): The attribute name of the socket.
-            index (int): The index of the socket in the parent item.
-            preset (str): The preset value of the socket.
-            data_type (Any): The data type of the socket.
-            max_connections (int): The maximum number of connections the socket
-                can have.
+            mode (AttrModel): The attribute's description.
+            config (dict): The Nodz configuration dict.
         """
         super(SocketItem, self).__init__(
             parent,
-            attribute,
-            preset,
-            index,
-            data_type,
-            max_connections,
+            model,
             config,
         )
 
         # Storage.
-        self.attributte = attribute
-        self.preset = preset
-        self.slot_type = "socket"
+        self.slot_type = SlotItem.Type.Socket
 
         # Methods.
-        self._create_style(parent)
+        self._create_style()
 
-    def to_dict(self) -> dict:
-        """
-        Serialize the socket item to a dict.
-        """
-        d = dict(super().to_dict())
-        d.update(
-            {"socket": True, "socketMaxConnections": self.max_connections}
-        )
-        return d
-
-    def _create_style(self, parent: QtWidgets.QGraphicsItem) -> None:
+    def _create_style(self) -> None:
         """
         Read the attribute style from the configuration file.
         """
@@ -1004,7 +898,7 @@ class SocketItem(SlotItem):
         self.brush = QtGui.QBrush()
         self.brush.setStyle(QtCore.Qt.BrushStyle.SolidPattern)
         self.brush.setColor(
-            utils._convert_data_to_color(config[self.preset]["socket"])
+            _convert_data_to_color(config[self.model.preset]["socket"])
         )
 
     def boundingRect(self) -> QtCore.QRectF:
@@ -1022,7 +916,7 @@ class SocketItem(SlotItem):
             self.parent_node_item().base_height
             - config["node_radius"]
             + (self.parent_node_item().attr_height / 4)
-            + self.parent_node_item().attrs.index(self.attribute)
+            + self.parent_node_item().attrs.index(self.model.attribute)
             * self.parent_node_item().attr_height
         )
 
@@ -1046,8 +940,8 @@ class SocketItem(SlotItem):
 
         # Populate connection.
         connection.plug_item = item
-        connection.socket_node = self.parent_node_item().name
-        connection.socket_attr = self.attribute
+        connection.model.socket_node = self.parent_node_item().model.name
+        connection.model.socket_attr = self.model.attribute
 
         # Add plug to connected slots.
         self.connected_slots.append(item)
@@ -1057,12 +951,7 @@ class SocketItem(SlotItem):
             self.connections.append(connection)
 
         # Emit signal.
-        self.scene().signal_SocketConnected.emit(
-            connection.plug_node,
-            connection.plug_attr,
-            connection.socket_node,
-            connection.socket_attr,
-        )
+        self.scene().signal_SocketConnected.emit(connection.model)  # type: ignore
 
     def disconnect(self, connection: ConnectionItem) -> None:
         """
@@ -1072,12 +961,7 @@ class SocketItem(SlotItem):
             connection (ConnectionItem): The connection to disconnect.
         """
         # Emit signal.
-        self.scene().signal_SocketDisconnected.emit(
-            connection.plug_node,
-            connection.plug_attr,
-            connection.socket_node,
-            connection.socket_attr,
-        )
+        self.scene().signal_SocketDisconnected.emit(connection.model)  # type: ignore
 
         # Remove connected plugs
         if connection.plug_item in self.connected_slots:
@@ -1097,7 +981,7 @@ class ConnectionItem(QtWidgets.QGraphicsPathItem):
         source_point: QtCore.QPoint,
         target_point: QtCore.QPoint,
         source: SlotItem,
-        target: SlotItem | None,
+        target: Union[SlotItem, None],
     ) -> None:
         """
         Initialize the class.
@@ -1113,11 +997,12 @@ class ConnectionItem(QtWidgets.QGraphicsPathItem):
         self.setZValue(1)
 
         # Storage.
-        self.socket_node: str | None = None
-        self.socket_attr: str | None = None
-        self.plug_node: str | None = None
-        self.plug_attr: str | None = None
-
+        self.model = ConnectionModel(
+            plug_node=source.parent_node_item().model.name,
+            plug_attr=source.model.attribute,
+            socket_node=target.parent_node_item().model.name if target else "",
+            socket_attr=target.model.attribute if target else "",
+        )
         self.source_point = source_point
         self.target_point = target_point
         self.source = source
@@ -1142,7 +1027,7 @@ class ConnectionItem(QtWidgets.QGraphicsPathItem):
         self.setZValue(-1)
 
         self._pen = QtGui.QPen(
-            utils._convert_data_to_color(config["connection_color"])
+            _convert_data_to_color(config["connection_color"])
         )
         self._pen.setWidth(config["connection_width"])
 
@@ -1185,9 +1070,9 @@ class ConnectionItem(QtWidgets.QGraphicsPathItem):
         """
         Move the Connection with the mouse.
         """
-        config = self.scene().config
+        config = self.scene().config  # type: ignore
 
-        mbb = utils._create_pointer_bounding_box(
+        mbb = _create_pointer_bounding_box(
             pointer_pos=event.scenePos().toPoint(),
             bb_size=config["mouse_bounding_box"],
         )
@@ -1295,8 +1180,110 @@ class ConnectionItem(QtWidgets.QGraphicsPathItem):
 
         self.setPath(path)
 
-    def to_tuple(self) -> tuple:
+    def to_tuple(self) -> Tuple[str, str]:
+        """Serialze to a tuple."""
         return (
-            f"{self.plug_node}.{self.plug_attr}",
-            f"{self.socket_node}.{self.socket_attr}",
+            f"{self.model.plug_node}.{self.model.plug_attr}",
+            f"{self.model.socket_node}.{self.model.socket_attr}",
         )
+
+
+class ItemFactory:
+    """
+    Allows for creation of (subclassed) items with custom instanciation logic.
+    """
+
+    def __init__(
+        self,
+        node_cls: type[NodeItem] = NodeItem,
+        slot_cls: type[SlotItem] = SlotItem,
+        plug_cls: type[PlugItem] = PlugItem,
+        socket_cls: type[SocketItem] = SocketItem,
+        connection_cls: type[ConnectionItem] = ConnectionItem,
+    ) -> None:
+        """
+        Initialize the factory with classes for nodes, slots and connections.
+
+        Args:
+            node_cls (type[NodeItem]): Class for node items.
+            slot_cls (type[SlotItem]): Class for slot items.
+            plug_cls (type[PlugItem]): Class for plug items.
+            socket_cls (type[SocketItem]): Class for socket items.
+            connection_cls (type[ConnectionItem]): Class for connection items.
+        """
+        self.node_cls = node_cls
+        self.slot_cls = slot_cls
+        self.plug_cls = plug_cls
+        self.socket_cls = socket_cls
+        self.connection_cls = connection_cls
+
+    def create_node(self, model: NodeModel, config: dict) -> NodeItem:
+        """
+        Create a new node item with the registered node item class.
+        """
+        return self.node_cls(model, config)
+
+    def create_slot(
+        self,
+        parent: NodeItem | None,
+        model: AttrModel,
+        config: dict,
+    ) -> SlotItem:
+        """
+        Create a new slot item with the registered slot item class.
+        """
+        return self.slot_cls(
+            parent,
+            model,
+            config,
+        )
+
+    def create_plug(
+        self,
+        parent: NodeItem,
+        model: AttrModel,
+        config: dict,
+    ) -> PlugItem:
+        """
+        Create a new plug item with the registered plug item class.
+        """
+        return self.plug_cls(
+            parent,
+            model,
+            config,
+        )
+
+    def create_socket(
+        self,
+        parent: NodeItem,
+        model: AttrModel,
+        config: dict,
+    ) -> SocketItem:
+        """
+        Create a new socket item with the registered socket item class.
+        """
+        return self.socket_cls(
+            parent,
+            model,
+            config,
+        )
+
+    def create_connection(
+        self,
+        source_point: QtCore.QPoint,
+        target_point: QtCore.QPoint,
+        source: SlotItem,
+        target: Union[SlotItem, None],
+    ) -> ConnectionItem:
+        """
+        Create a new connection item with the registered connection item class.
+        """
+        return self.connection_cls(source_point, target_point, source, target)
+
+
+def scene_factory(cls) -> ItemFactory:
+    """Return the scene factory for the given node item class."""
+    try:
+        return cls.scene().factory
+    except AttributeError:
+        raise

--- a/nodz/scene.py
+++ b/nodz/scene.py
@@ -3,15 +3,21 @@ import os
 from typing import Any, Optional
 from qtpy import QtGui, QtCore, QtWidgets
 
-from .items import PlugItem, SocketItem, NodeItem, ConnectionItem
-from nodz.utils import (
+from .items import (
+    PlugItem,
+    SocketItem,
+    NodeItem,
+    ConnectionItem,
+    ItemFactory,
+)
+from .utils import (
     nlog,
     _convert_data_to_color,
     _load_config,
-    _swap_list_indices,
     _load_data,
     _save_data,
 )
+from .data_types import NodeModel
 
 
 class NodeScene(QtWidgets.QGraphicsScene):
@@ -20,22 +26,22 @@ class NodeScene(QtWidgets.QGraphicsScene):
     """
 
     signal_NodeCreated = QtCore.Signal(object)  # type: ignore (qtpy)
-    signal_NodeDeleted = QtCore.Signal(object)  # type: ignore (qtpy)
-    signal_NodeEdited = QtCore.Signal(object, object)  # type: ignore (qtpy)
+    signal_NodeDeleted = QtCore.Signal(str)  # type: ignore (qtpy)
+    signal_NodeEdited = QtCore.Signal(str, str)  # type: ignore (qtpy)
     signal_NodeSelected = QtCore.Signal(object)  # type: ignore (qtpy)
-    signal_NodeMoved = QtCore.Signal(str, object)  # type: ignore (qtpy)
-    signal_NodeDoubleClicked = QtCore.Signal(str)  # type: ignore (qtpy)
+    signal_NodeMoved = QtCore.Signal(object, object)  # type: ignore (qtpy)
+    signal_NodeDoubleClicked = QtCore.Signal(object)  # type: ignore (qtpy)
 
     signal_AttrCreated = QtCore.Signal(object, object)  # type: ignore (qtpy)
-    signal_AttrDeleted = QtCore.Signal(object, object)  # type: ignore (qtpy)
-    signal_AttrEdited = QtCore.Signal(object, object, object)  # type: ignore (qtpy)
+    signal_AttrDeleted = QtCore.Signal(object, int)  # type: ignore (qtpy)
+    signal_AttrEdited = QtCore.Signal(object, int, int)  # type: ignore (qtpy)
 
-    signal_PlugConnected = QtCore.Signal(object, object, object, object)  # type: ignore (qtpy)
-    signal_PlugDisconnected = QtCore.Signal(object, object, object, object)  # type: ignore (qtpy)
-    signal_SocketConnected = QtCore.Signal(object, object, object, object)  # type: ignore (qtpy)
-    signal_SocketDisconnected = QtCore.Signal(object, object, object, object)  # type: ignore (qtpy)
+    signal_PlugConnected = QtCore.Signal(object)  # type: ignore (qtpy)
+    signal_PlugDisconnected = QtCore.Signal(object)  # type: ignore (qtpy)
+    signal_SocketConnected = QtCore.Signal(object)  # type: ignore (qtpy)
+    signal_SocketDisconnected = QtCore.Signal(object)  # type: ignore (qtpy)
 
-    signal_RemoveConnections = QtCore.Signal(object, object, object, object)  # type: ignore (qtpy)
+    signal_RemoveConnections = QtCore.Signal(object)  # type: ignore (qtpy)
 
     signal_Dropped = QtCore.Signal()  # type: ignore (qtpy)
 
@@ -57,6 +63,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
 
         # General.
         self.config = config
+        self.factory = ItemFactory()
         self.grid_size = parent.config["grid_size"]
         self.grid_vis_toggle = True
         self.grid_snap_toggle = False
@@ -68,21 +75,23 @@ class NodeScene(QtWidgets.QGraphicsScene):
         self.selectionChanged.connect(self.selection_changed)
         self.selectionChanged.connect(self._return_selection)
 
+    def register_factory(self, factory) -> None:
+        self.factory = factory
+
     def addItem(self, item: QtWidgets.QGraphicsItem):
         """Extends QGraphicsScene.addItem to update the _node_dict."""
         if isinstance(item, NodeItem):
-            self._node_dict[item.name] = item
+            self._node_dict[item.model.name] = item
         super().addItem(item)
 
     def removeItem(self, item: QtWidgets.QGraphicsItem):
-        """Extends QGraphicsScene.addItem to update the _node_dict."""
+        """Extends QGraphicsScene.removeItem to update the _node_dict."""
         if isinstance(item, NodeItem):
-            del self._node_dict[item.name]
-            # FIXME: delete connections to/from this node
+            del self._node_dict[item.model.name]
         super().removeItem(item)
 
     def clear(self):
-        """Extends QGraphicsScene.addItem to update the _node_dict."""
+        """Extends QGraphicsScene.clear to update the _node_dict."""
         self._node_dict = dict()
         super().clear()
 
@@ -136,7 +145,6 @@ class NodeScene(QtWidgets.QGraphicsScene):
             grid_size = self.grid_size
             epos_x = event.scenePos().x()
             epos_y = event.scenePos().y()
-            # print(f"event_pos {epos_x} {epos_y}")
 
             for node_item in selected:
                 node_rect = node_item.boundingRect()
@@ -144,7 +152,6 @@ class NodeScene(QtWidgets.QGraphicsScene):
                     epos_x - node_rect.width() / 2,
                     epos_y - node_rect.height() / 2,
                 )
-                # print(f"current_pos {node_item.name} {current_pos}")
                 snap_x = (
                     round(current_pos.x() / grid_size) * grid_size
                 ) - grid_size / 4
@@ -239,7 +246,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
         if self.selectedItems():
             for node in self.selectedItems():
                 if node in self.node_items():
-                    selected_nodes.append(node.name)
+                    selected_nodes.append(node.model.name)  # type: ignore
 
         # Emit signal.
         self.signal_NodeSelected.emit(selected_nodes)
@@ -301,6 +308,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
         preset: str = "node_default",
         position: Optional[QtCore.QPointF] = None,
         alternate: bool = True,
+        **kwargs,
     ) -> NodeItem:
         """
         Create a new node with a given name, position and color.
@@ -320,16 +328,13 @@ class NodeScene(QtWidgets.QGraphicsScene):
                 f"A node with the same name already exists : {name}"
             )
 
-        node_item = NodeItem(
-            name,
-            alternate,
-            preset,
-            self.config,
+        node_item = self.factory.create_node(
+            NodeModel(name, alternate, preset, kwargs=kwargs), self.config
         )
         self.add_node(node_item, position=position)
 
         # Emit signal.
-        self.signal_NodeCreated.emit(name)
+        self.signal_NodeCreated.emit(node_item.model)
 
         return node_item
 
@@ -346,13 +351,12 @@ class NodeScene(QtWidgets.QGraphicsScene):
             return
 
         if node in self.node_items():
-            node_name = node.name
             node._remove_connections()
             # Remove node.
             self.removeItem(node)
             self.update()
             # Emit signal.
-            self.signal_NodeDeleted.emit([node_name])
+            self.signal_NodeDeleted.emit(node.model.name)
 
     def api_edit_node(self, node, new_name: str) -> None:
         """
@@ -367,7 +371,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
             nlog.error("Node edition aborted !")
             return
 
-        old_name = node.name
+        old_name = node.model.name
 
         # Check for name clashes
         if new_name in self.node_names():
@@ -377,7 +381,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
             nlog.error("Node edition aborted !")
             return
         else:
-            node.name = new_name
+            node.model.name = new_name
 
         # Replace node data.
         self._node_dict[new_name] = self._node_dict[old_name]
@@ -411,6 +415,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
         data_type: Any = None,
         plug_max_connections: int = -1,
         socket_max_connections: int = 1,
+        **kwargs,
     ) -> None:
         """
         Create a new attribute with a given name.
@@ -441,7 +446,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
             nlog.error("Attribute creation aborted !")
             return
 
-        node._create_attribute(
+        final_index = node._create_attribute(
             name=name,
             index=index,
             preset=preset,
@@ -450,10 +455,11 @@ class NodeScene(QtWidgets.QGraphicsScene):
             data_type=data_type,
             plug_max_connections=plug_max_connections,
             socket_max_connections=socket_max_connections,
+            **kwargs,
         )
 
         # Emit signal.
-        self.signal_AttrCreated.emit(node.name, index)
+        self.signal_AttrCreated.emit(node.model, final_index)
 
     def api_delete_attribute(self, node: NodeItem, index: int) -> None:
         """
@@ -471,7 +477,7 @@ class NodeScene(QtWidgets.QGraphicsScene):
         node._delete_attribute(index)
 
         # Emit signal.
-        self.signal_AttrDeleted.emit(node.name, index)
+        self.signal_AttrDeleted.emit(node.model, index)
 
     def api_edit_attribute(
         self,
@@ -505,28 +511,24 @@ class NodeScene(QtWidgets.QGraphicsScene):
                 old_name = node.attrs[index]
 
             # Rename in the slot item(s).
-            if node.attrs_data[old_name]["plug"]:
-                node.plugs[old_name].attribute = new_name
+            if node.attrs_data[old_name].plug:
+                node.plugs[old_name].model.attribute = new_name
                 node.plugs[new_name] = node.plugs[old_name]
                 node.plugs.pop(old_name)
                 for connection in node.plugs[new_name].connections:
                     connection.plugAttr = new_name
 
-            if node.attrs_data[old_name]["socket"]:
-                node.sockets[old_name].attribute = new_name
+            if node.attrs_data[old_name].socket:
+                node.sockets[old_name].model.attribute = new_name
                 node.sockets[new_name] = node.sockets[old_name]
                 node.sockets.pop(old_name)
                 for connection in node.sockets[new_name].connections:
                     connection.socketAttr = new_name
 
-            # Replace attribute data.
-            node.attrs_data[old_name]["name"] = new_name
-            node.attrs_data[new_name] = node.attrs_data[old_name]
-            node.attrs_data.pop(old_name)
-            node.attrs[index] = new_name
-
         if isinstance(new_index, int):
-            _swap_list_indices(node.attrs, index, new_index)
+            # swap attributes in the model
+            alist = node.model.attributes
+            alist[new_index], alist[index] = alist[index], alist[new_index]
 
             # Refresh connections.
             for plug in node.plugs.values():
@@ -563,9 +565,9 @@ class NodeScene(QtWidgets.QGraphicsScene):
 
         # Emit signal.
         if new_index:
-            self.signal_AttrEdited.emit(node.name, index, new_index)
+            self.signal_AttrEdited.emit(node.model, index, new_index)
         else:
-            self.signal_AttrEdited.emit(node.name, index, index)
+            self.signal_AttrEdited.emit(node.model, index, index)
 
     # GRAPH
     def api_save_graph(self, file_path: str) -> None:
@@ -614,25 +616,28 @@ class NodeScene(QtWidgets.QGraphicsScene):
         nodes_data = data["NODES"]
 
         for name, d in nodes_data.items():
+            del d["name"]
+            attr_list = d.pop("attributes")
             node_item = self.api_create_node(
                 name,
-                d["preset"],
-                d["position"],
-                d["alternate"],
+                d.pop("preset"),
+                d.pop("position"),
+                d.pop("alternate"),
+                **d.pop("kwargs"),
             )
-            for ad in d["attributes"]:
+            for ad in attr_list:
                 self.api_create_attribute(
                     node_item,
-                    name=ad["name"],
-                    index=ad["index"],
-                    preset=ad["preset"],
-                    plug=ad["plug"],
-                    socket=ad["socket"],
-                    data_type=ad["dataType"],
-                    plug_max_connections=ad["plugMaxConnections"],
-                    socket_max_connections=ad["socketMaxConnections"],
+                    name=ad.pop("attribute"),
+                    index=ad.pop("index"),
+                    preset=ad.pop("preset"),
+                    plug=ad.pop("plug"),
+                    socket=ad.pop("socket"),
+                    data_type=ad.pop("data_type"),
+                    plug_max_connections=ad.pop("plug_max_connections"),
+                    socket_max_connections=ad.pop("socket_max_connections"),
+                    **ad.pop("kwargs"),
                 )
-            self.addItem(node_item)
 
         # Apply connections data.
         connections_data = data["CONNECTIONS"]
@@ -674,14 +679,14 @@ class NodeScene(QtWidgets.QGraphicsScene):
         plug = self._node_dict[source_node].plugs[source_attr]
         socket = self._node_dict[target_node].sockets[target_attr]
 
-        connection = ConnectionItem(
+        connection = self.factory.create_connection(
             plug.center(), socket.center(), plug, socket
         )
 
-        connection.plug_node = plug.parentItem().name
-        connection.plug_attr = plug.attribute
-        connection.socket_node = socket.parentItem().name
-        connection.socket_attr = socket.attribute
+        connection.model.plug_node = plug.parentItem().model.name
+        connection.model.plug_attr = plug.model.attribute
+        connection.model.socket_node = socket.parentItem().model.name
+        connection.model.socket_attr = socket.model.attribute
 
         plug.connect(socket, connection)
         socket.connect(plug, connection)

--- a/nodz/utils.py
+++ b/nodz/utils.py
@@ -14,18 +14,15 @@ def _convert_data_to_color(
     data: list, alternate: bool = False, av: int = 20
 ) -> QtGui.QColor:
     """
-    Convert a list of 3 (rgb) or 4(rgba) values from the configuration
-    file into a QColor.
+    Convert a list of RGB or RGBA values from the configuration to a
+    QtGui.QColor object.
 
-    :param data: Input color.
-    :type  data: List.
-
-    :param alternate: Whether or not this is an alternate color.
-    :type  alternate: Bool.
-
-    :param av: Alternate value.
-    :type  av: Int.
-
+    Args:
+        data (list): Input list of RGB or RGBA values.
+        alternate (bool): Whether to generate an alternate color.
+        av (int): The amount to adjust the color values by.
+    Returns:
+        QtGui.QColor: A QColor object
     """
     # rgb
     if len(data) == 3:
@@ -68,15 +65,14 @@ def _generate_alternate_color_multiplier(
     color: QtGui.QColor, av: int
 ) -> float:
     """
-    Generate a multiplier based on the input color lighness to increase
+    Generate a multiplier based on the input color lightness to increase
     the alternate value for dark color or reduce it for bright colors.
 
-    :param color: Input color.
-    :type  color: QColor.
-
-    :param av: Alternate value.
-    :type  av: Int.
-
+    Args:
+        color (QtGui.QColor): Input color.
+        av (int): Alternate value.
+    Returns:
+        float: Multiplier based on color lightness.
     """
     lightness = color.lightness()
     mult = float(lightness) / 255
@@ -88,14 +84,13 @@ def _create_pointer_bounding_box(
     pointer_pos: QtCore.QPoint, bb_size: int
 ) -> QtCore.QRectF:
     """
-    generate a bounding box around the pointer.
+    Generate a bounding box around the pointer.
 
-    :param pointer_pos: Pointer position.
-    :type  pointer_pos: QPoint.
-
-    :param bb_size: Width and Height of the bounding box.
-    :type  bb_size: Int.
-
+    Args:
+        pointer_pos (QtCore.QPoint): Pointer position.
+        bb_size (int): Width and Height of the bounding box.
+    Returns:
+        QtCore.QRectF: Bounding box around the pointer.
     """
     # Create pointer's bounding box.
     point = pointer_pos
@@ -110,41 +105,15 @@ def _create_pointer_bounding_box(
     return bb
 
 
-def _swap_list_indices(
-    input_list: list, old_index: int, new_index: int
-) -> None:
-    """
-    Simply swap 2 indices in a the specified list.
-
-    :param input_list: List that contains the elements to swap.
-    :type  input_list: List.
-
-    :param old_index: Index of the element to move.
-    :type  old_index: Int.
-
-    :param new_index: Destination index of the element.
-    :type  new_index: Int.
-
-    """
-    if old_index == -1:
-        old_index = len(input_list) - 1
-
-    if new_index == -1:
-        new_index = len(input_list)
-
-    value = input_list[old_index]
-    input_list.pop(old_index)
-    input_list.insert(new_index, value)
-
-
 # IO
 def _load_config(file_path: str) -> dict:
     """
     Read the configuration file and strips out comments.
 
-    :param file_path: File path.
-    :type  file_path: Str.
-
+    Args:
+        file_path (str): Path to the configuration
+    Returns:
+        dict: Configuration data.
     """
     with open(file_path, "r") as myfile:
         file_string = myfile.read()
@@ -161,42 +130,56 @@ def _save_data(file_path: str, data: dict) -> None:
     """
     save data as a .json file
 
-    :param file_path: Path of the .json file.
-    :type  file_path: Str.
-
-    :param data: Data you want to save.
-    :type  data: Dict or List.
-
+    Args:
+        file_path (str): Path to json file to save to.
+        data (dict): Data to save.
     """
+
+    def _encoder(obj):
+        if isinstance(obj, QtCore.QPointF):
+            obj = (obj.x(), obj.y())
+        elif isinstance(obj, type):
+            obj = str(obj)
+        return obj
+
     f = open(file_path, "w")
-    f.write(json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False))
+    f.write(
+        json.dumps(
+            data,
+            sort_keys=True,
+            indent=4,
+            ensure_ascii=False,
+            default=_encoder,
+        )
+    )
     f.close()
 
     nlog.info("Data successfully saved !")
-
-
-def _decoder(d: dict):
-    """decode specific fields to avoid code duplication."""
-
-    if "position" in d:
-        d["position"] = QtCore.QPointF(*d["position"])
-
-    if "dataType" in d:
-        data_type = d["dataType"]
-        if isinstance(data_type, str) and data_type.find("<") == 0:
-            d["dataType"] = eval(str(data_type.split("'")[1]))
-
-    return d
 
 
 def _load_data(file_path: str) -> dict:
     """
     load data from a .json file.
 
-    :param file_path: Path of the .json file.
-    :type  file_path: Str.
-
+    Args:
+        file_path (str): Path to the json file to load.
+    Returns:
+        dict: dict loaded from the file.
     """
+
+    def _decoder(d: dict):
+        """decode specific fields to avoid code duplication."""
+
+        if "position" in d:
+            d["position"] = QtCore.QPointF(*d["position"])
+
+        if "data_type" in d:
+            data_type = d["data_type"]
+            if isinstance(data_type, str) and data_type.find("<") == 0:
+                d["data_type"] = eval(str(data_type.split("'")[1]))
+
+        return d
+
     with open(file_path) as json_file:
         j_data = json.load(json_file, object_hook=_decoder)
 

--- a/nodz/view.py
+++ b/nodz/view.py
@@ -33,11 +33,11 @@ class Nodz(QtWidgets.QGraphicsView):
 
     """
 
-    # FIXME: Somehow QtCore.Signal is flagged by pylance as
+    # NOTE: Somehow QtCore.Signal is flagged by pylance as
     # not exported by qtpy.QtCore...
 
     signal_KeyPressed = QtCore.Signal(object)  # type: ignore (qtpy)
-    signal_NodeMoved = QtCore.Signal(str, object)  # type: ignore (qtpy)
+    signal_NodeMoved = QtCore.Signal(object, object)  # type: ignore (qtpy)
     delete_selected_nodes = QtCore.Signal()  # type: ignore (qtpy)
     snap_node_to_grid = QtCore.Signal(bool)  # type: ignore (qtpy)
     selection_changed = QtCore.Signal(bool)  # type: ignore (qtpy)
@@ -471,7 +471,7 @@ class Nodz(QtWidgets.QGraphicsView):
             if all(len(plug.connections) == 0 for plug in node.plugs.values())
         ]
         nlog.debug(
-            f"_layout_graph: root_nodes: {[n.name for n in root_nodes]}"
+            f"_layout_graph: root_nodes: {[n.model.name for n in root_nodes]}"
         )
 
         start_x_pos = h_spacing
@@ -548,7 +548,7 @@ class Nodz(QtWidgets.QGraphicsView):
                 rect = rect.united(item.sceneBoundingRect())
         return rect if rect else QtCore.QRectF()
 
-    def initialize(self) -> None:
+    def initialize(self, node_factory=None) -> None:
         """
         Setup the view's behavior.
         """
@@ -585,6 +585,8 @@ class Nodz(QtWidgets.QGraphicsView):
         scene_width = config["scene_width"]
         scene_height = config["scene_height"]
         self._scene.setSceneRect(0, 0, scene_width, scene_height)
+        if node_factory:
+            self._scene.register_factory(node_factory)
         self.setScene(self._scene)
 
         # Connect scene node signals
@@ -610,10 +612,11 @@ class Nodz(QtWidgets.QGraphicsView):
         preset: str = "node_default",
         position: Optional[QtCore.QPointF] = None,
         alternate: bool = True,
+        **kwargs,
     ) -> str:
         return self._scene.api_create_node(
-            name, preset, position, alternate
-        ).name
+            name, preset, position, alternate, **kwargs
+        ).model.name
 
     def delete_node(self, node_name: str) -> None:
         self._scene.api_delete_node(self._scene.node_by_name(node_name))
@@ -621,7 +624,7 @@ class Nodz(QtWidgets.QGraphicsView):
     def edit_node(self, node_name: str, new_name: str) -> str:
         node = self._scene.node_by_name(node_name)
         self._scene.api_edit_node(node, new_name)
-        return node.name
+        return node.model.name
 
     def create_attribute(
         self,
@@ -634,6 +637,7 @@ class Nodz(QtWidgets.QGraphicsView):
         data_type: Any = None,
         plug_max_connections: int = -1,
         socket_max_connections: int = 1,
+        **kwargs,
     ) -> None:
         self._scene.api_create_attribute(
             self._scene.node_by_name(node_name),
@@ -645,6 +649,7 @@ class Nodz(QtWidgets.QGraphicsView):
             data_type,
             plug_max_connections,
             socket_max_connections,
+            **kwargs,
         )
 
     def delete_attribute(self, node_name: str, index: int) -> None:

--- a/nodz_demo.py
+++ b/nodz_demo.py
@@ -1,8 +1,9 @@
-from typing import Any
+from typing import Union
 from qtpy import QtCore, QtGui, QtWidgets
 import nodz.view as view
 import nodz.items as items
 from nodz.utils import nlog
+from nodz.data_types import NodeModel, AttrModel, ConnectionModel
 
 try:
     app = QtWidgets.QApplication([])
@@ -11,113 +12,134 @@ except BaseException:
     app = None
 
 ######################################################################
-# Test subclasses
+# Test subclasses and factory
 ######################################################################
 
 
-# class TestNode(items.NodeItem):
-#     def __init__(
-#         self,
-#         name: str,
-#         alternate: bool,
-#         preset: str,
-#         config: dict,
-#         help: str = "",
-#     ) -> None:
-#         super().__init__(name, alternate, preset, config)
-#         self.help = help if help else "This is a subclassed node."
+class TestNode(items.NodeItem):
+    """
+    Derived class adding a tooltip on the node and changing the attributes'
+    label alignment based on its category (slot, plug or socket).
+    """
 
-#     def to_dict(self) -> dict:
-#         d = super().to_dict()
-#         d["help"] = self.help
-#         return d
+    def __init__(
+        self,
+        model: NodeModel,
+        config: dict,
+        help="%(name)s is a TestNode",
+    ) -> None:
+        super().__init__(model, config)
+        if self.model.kwargs.get("help") != help:
+            self.model.kwargs["help"] = help
+        self.setToolTip(self.model.kwargs["help"] % self.model.to_dict())
 
-#     def configure_from_dict(self, d: dict) -> None:
-#         if d and "help" in d:
-#             self.help = d["help"]
+    def paint_attr_label(
+        self,
+        attr: str,
+        painter: QtGui.QPainter,
+        rect: QtCore.QRect,
+        align_flag: QtCore.Qt.AlignmentFlag = QtCore.Qt.AlignmentFlag.AlignVCenter,
+    ):
+        attr_data = self.attrs_data[attr]
 
-#     def paint_attr_label(
-#         self,
-#         attr: str,
-#         painter: QtGui.QPainter,
-#         rect: QtCore.QRect,
-#         align_flag: QtCore.Qt.AlignmentFlag = QtCore.Qt.AlignmentFlag.AlignVCenter,
-#     ):
-#         attr_data = self.attrs_data[attr]
+        align_flag = QtCore.Qt.AlignmentFlag.AlignVCenter | (
+            QtCore.Qt.AlignmentFlag.AlignLeft
+            if attr_data.socket and not attr_data.plug
+            else QtCore.Qt.AlignmentFlag.AlignRight
+            if attr_data.plug and not attr_data.socket
+            else QtCore.Qt.AlignmentFlag.AlignCenter
+        )
 
-#         align_flag = (
-#             QtCore.Qt.AlignmentFlag.AlignVCenter
-#             if attr_data["socket"] and not attr_data["plug"]
-#             else QtCore.Qt.AlignmentFlag.AlignVCenter
-#             | QtCore.Qt.AlignmentFlag.AlignRight
-#             if attr_data["plug"] and not attr_data["socket"]
-#             else QtCore.Qt.AlignmentFlag.AlignCenter
-#         )
-#         super().paint_attr_label(
-#             attr,
-#             painter,
-#             rect,
-#             align_flag=align_flag,
-#         )
+        super().paint_attr_label(
+            attr,
+            painter,
+            rect,
+            align_flag=align_flag,
+        )
 
 
-# class TestPlug(items.PlugItem):
-#     def __init__(
-#         self,
-#         parent: QtWidgets.QGraphicsItem,
-#         attribute: str,
-#         index: int,
-#         preset: str,
-#         data_type: Any,
-#         max_connections: int,
-#         help: str = "",
-#     ) -> None:
-#         super().__init__(
-#             parent, attribute, index, preset, data_type, max_connections
-#         )
-#         self.help = help if help else "This is a subclassed plug."
+class TestPlug(items.PlugItem):
+    """
+    Derived class adding a tooltip on the plug.
+    """
 
-#     def to_dict(self) -> dict:
-#         d = super().to_dict()
-#         d["help"] = self.help
-#         return d
-
-#     def configure_from_dict(self, d: dict) -> None:
-#         if d and "help" in d:
-#             self.help = d["help"]
+    def __init__(
+        self,
+        parent: QtWidgets.QGraphicsItem,
+        model: AttrModel,
+        config: dict,
+        help="%(attribute)s is a TestPlug of type %(data_type)s",
+    ) -> None:
+        super().__init__(
+            parent,
+            model,
+            config,
+        )
+        if self.model.kwargs.get("help") != help:
+            self.model.kwargs["help"] = help
+        self.setToolTip(self.model.kwargs["help"] % self.model.to_dict())
 
 
-# class TestSocket(items.SocketItem):
-#     def __init__(
-#         self,
-#         parent: QtWidgets.QGraphicsItem,
-#         attribute: str,
-#         index: int,
-#         preset: str,
-#         data_type: Any,
-#         max_connections: int,
-#         help: str = "",
-#     ) -> None:
-#         super().__init__(
-#             parent, attribute, index, preset, data_type, max_connections
-#         )
-#         self.help = help if help else "This is a subclassed socket."
+class TestSocket(items.SocketItem):
+    """
+    Derived class adding a tooltip on the socket.
+    """
 
-#     def to_dict(self) -> dict:
-#         d = super().to_dict()
-#         d["help"] = self.help
-#         return d
-
-#     def configure_from_dict(self, d: dict) -> None:
-#         if d and "help" in d:
-#             self.help = d["help"]
+    def __init__(
+        self,
+        parent: QtWidgets.QGraphicsItem,
+        model: AttrModel,
+        config: dict,
+        help="%(attribute)s  is a TestSocket of type %(data_type)s",
+    ) -> None:
+        super().__init__(
+            parent,
+            model,
+            config,
+        )
+        if self.model.kwargs.get("help") != help:
+            self.model.kwargs["help"] = help
+        self.setToolTip(self.model.kwargs["help"] % self.model.to_dict())
 
 
+class TestConnection(items.ConnectionItem):
+    def __init__(
+        self,
+        source_point: QtCore.QPoint,
+        target_point: QtCore.QPoint,
+        source: items.SlotItem,
+        target: Union[items.SlotItem, None],
+    ) -> None:
+        super().__init__(source_point, target_point, source, target)
+
+    def set_connection_color(self, color):
+        self._pen.setColor(color)
+
+
+# We can create a new factory inheriting from NodeFactory to implement
+# custom logic when instancing items.
+class TestFactory(items.ItemFactory):
+    def create_connection(
+        self,
+        source_point: QtCore.QPoint,
+        target_point: QtCore.QPoint,
+        source: items.SlotItem,
+        target: Union[items.SlotItem, None],
+    ) -> items.ConnectionItem:
+        c = TestConnection(source_point, target_point, source, target)
+        if source.model.data_type is str:
+            c.set_connection_color("#55AA55")
+        return c
+
+
+# We replace some of the standard item classes with our own.
+test_factory = TestFactory(
+    node_cls=TestNode, plug_cls=TestPlug, socket_cls=TestSocket
+)
 nodz = view.Nodz(
     None,
 )
-# nodz.loadConfig(filePath='')
-nodz.initialize()
+nodz.initialize(node_factory=test_factory)
 nodz.show()
 
 
@@ -127,90 +149,94 @@ nodz.show()
 
 
 # Nodes
-@QtCore.Slot(str)  # type: ignore
-def on_nodeCreated(nodeName):
-    nlog.info(f"node created : {nodeName}")
+@QtCore.Slot(object)  # type: ignore
+def on_nodeCreated(node_model: NodeModel):
+    nlog.info(f"> node created : {node_model.name}")
 
 
 @QtCore.Slot(str)  # type: ignore
-def on_nodeDeleted(nodeName):
-    nlog.info(f"node deleted : {nodeName}")
+def on_nodeDeleted(node_name):
+    nlog.info(f"> node deleted : {node_name}")
 
 
 @QtCore.Slot(str, str)  # type: ignore
-def on_nodeEdited(nodeName, newName):
-    nlog.info(f"node edited : {nodeName}, new name : {newName}")
+def on_nodeEdited(node_name, new_name):
+    nlog.info(f"> node edited : {node_name}, new name : {new_name}")
 
 
-@QtCore.Slot(str)  # type: ignore
-def on_nodeSelected(nodesName):
-    nlog.info(f"node selected : {nodesName}")
+@QtCore.Slot(object)  # type: ignore
+def on_nodeSelected(nodes_names: list):
+    nlog.info(f"> node selected : {nodes_names}")
 
 
-@QtCore.Slot(str, object)  # type: ignore
-def on_nodeMoved(nodeName, nodePos):
-    nlog.info(f"node {nodeName} moved to {nodePos}")
+@QtCore.Slot(object, object)  # type: ignore
+def on_nodeMoved(node_model: NodeModel, nodePos: QtCore.QPointF):
+    nlog.info(f"> node {node_model.name} moved to {nodePos.toTuple()}")
 
 
-@QtCore.Slot(str)  # type: ignore
-def on_nodeDoubleClick(nodeName):
-    nlog.info(f"double click on node : {nodeName}")
+@QtCore.Slot(object)  # type: ignore
+def on_nodeDoubleClick(node_model: NodeModel):
+    nlog.info(f"> double click on node : {node_model.name}")
 
 
 # Attrs
-@QtCore.Slot(str, int)  # type: ignore
-def on_attrCreated(nodeName, attrId):
-    nlog.info(f"attr created : {nodeName} at index : {attrId}")
-
-
-@QtCore.Slot(str, int)  # type: ignore
-def on_attrDeleted(nodeName, attrId):
-    nlog.info(f"attr Deleted : {nodeName} at old index : {attrId}")
-
-
-@QtCore.Slot(str, int, int)  # type: ignore
-def on_attrEdited(nodeName, oldId, newId):
+@QtCore.Slot(object, int)  # type: ignore
+def on_attrCreated(model: NodeModel, attr_id: int):
     nlog.info(
-        f"attr Edited : {nodeName} at old index : {oldId}, new index : {newId}"
+        f"> attr created : {model.name}.{model.attributes[attr_id].attribute} "
+        f"at index : {attr_id}"
+    )
+
+
+@QtCore.Slot(object, int)  # type: ignore
+def on_attrDeleted(model: NodeModel, attr_id: int):
+    nlog.info(f"> attr Deleted : {model.name} at old index : {attr_id}")
+
+
+@QtCore.Slot(object, int, int)  # type: ignore
+def on_attrEdited(model: NodeModel, old_id: int, new_id: int):
+    nlog.info(
+        f"> attr Edited : {model.name}.{model.attributes[new_id].attribute} "
+        f"at old index : {old_id}, new index : {new_id}"
     )
 
 
 # Connections
-@QtCore.Slot(str, str, str, str)  # type: ignore
-def on_connected(srcNodeName, srcPlugName, destNodeName, dstSocketName):
+@QtCore.Slot(object)  # type: ignore
+def on_connected(model: ConnectionModel):
     nlog.info(
-        f'connected src: "{srcNodeName}" at "{srcPlugName}" to dst: '
-        f'"{destNodeName}" at "{dstSocketName}"'
+        f'> connected src: "{model.plug_node}" at "{model.plug_attr}" to dst: '
+        f'"{model.socket_node}" at "{model.socket_attr}"'
     )
 
 
-@QtCore.Slot(str, str, str, str)  # type: ignore
-def on_disconnected(srcNodeName, srcPlugName, destNodeName, dstSocketName):
+@QtCore.Slot(object)  # type: ignore
+def on_disconnected(model: ConnectionModel):
     nlog.info(
-        f'disconnected src: "{srcNodeName}" at "{srcPlugName}" from dst: '
-        f'"{destNodeName}" at "{dstSocketName}"'
+        f'> disconnected src: "{model.plug_node}" at "{model.plug_attr}" from dst: '
+        f'"{model.socket_node}" at "{model.socket_attr}"'
     )
 
 
 # Graph
 @QtCore.Slot()  # type: ignore
 def on_graphSaved():
-    nlog.info("graph saved !")
+    nlog.info("> graph saved !")
 
 
 @QtCore.Slot()  # type: ignore
 def on_graphLoaded():
-    nlog.info("graph loaded !")
+    nlog.info("> graph loaded !")
 
 
 @QtCore.Slot()  # type: ignore
 def on_graphCleared():
-    nlog.info("graph cleared !")
+    nlog.info("> graph cleared !")
 
 
 @QtCore.Slot()  # type: ignore
 def on_graphEvaluated():
-    nlog.info("graph evaluated !")
+    nlog.info("> graph evaluated !")
 
 
 # Other
@@ -254,7 +280,12 @@ nodz.signal_KeyPressed.connect(on_keyPressed)
 ######################################################################
 
 # Node A
-nodeA = nodz.create_node(name="nodeA", preset="node_preset_1", position=None)
+nodeA = nodz.create_node(
+    name="nodeA",
+    preset="node_preset_1",
+    position=None,
+    help="NodeA has it's own special help string !",
+)
 
 nodz.create_attribute(
     nodeA,
@@ -264,6 +295,7 @@ nodz.create_attribute(
     plug=True,
     socket=False,
     data_type=str,
+    help="Just checking this is working !",
 )
 
 nodz.create_attribute(
@@ -274,6 +306,7 @@ nodz.create_attribute(
     plug=False,
     socket=False,
     data_type=int,
+    help="This attribute is purely decorative and the tooltip won't show.",
 )
 
 nodz.create_attribute(
@@ -567,13 +600,13 @@ nodz.delete_node(nodeC)
 
 
 # Graph
-nlog.info(nodz.evaluate_graph())
+nlog.info(f"graph evaluation = {nodz.evaluate_graph()}")
 
-nodz.save_graph(file_path="Enter your path")
+nodz.save_graph(file_path="nodz_demo_graph.json")
 
 nodz.clear_graph()
 
-nodz.load_graph(file_path="Enter your path")
+nodz.load_graph(file_path="nodz_demo_graph.json")
 
 nodz._layout_graph()
 


### PR DESCRIPTION
## Changelog Description

### `ItemFactory`
Allows for creation of (subclassed) items with custom instantiation logic. See the demo for an example.

### `data_type.py`
- Defines `NodeModel`, `AttrModel` and `ConnectionModel` dataclasses used to:
  - initialize `NodeItem`, `SlotItem`, `PlugItem`, `SocketItem` and `ConnectionItem`
  - store their internal state
  - serialize them.
- Some signals are now passing relevant dataclasses.

### Misc.
- demo was updated to demonstrate usage of factory.
- removed un-used methods and data members.
- doc-string updates

## Additional review information
None.

## Testing notes:
1. launch the demo, play with the nodes.
2. Approve !
