### PR TITLE
Extend mode layout algorithm to support node groups

### DIFF
--- a/nodz/default_config.json
+++ b/nodz/default_config.json
@@ -11,6 +11,7 @@
 
     "horizontal_node_spacing": 80,
     "vertical_node_spacing": 40,
+    "group_padding": 50,
 
     "node_font": "Arial",
     "node_font_size": 12,

--- a/nodz/main.py
+++ b/nodz/main.py
@@ -7,10 +7,10 @@ It demonstrates how to use the MVC architecture to create a Nodz application.
 
 from __future__ import annotations
 
-import json
 import os
 import sys
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, TypedDict, Union
+
 from qtpy import QtCore, QtGui, QtWidgets
 
 from .slot_drawer import SlotDrawer
@@ -23,11 +23,18 @@ from .views import (
     NodeGroupView,
     CNCT_Z,
     CNCT_Z_UP,
-    NODE_Z,
     NODE_Z_UP,
 )
-from .controllers import NodzAPI, NodeGroupController
-from .utils import json_encoder, nlog
+from .controllers import NodzAPI
+from .utils import nlog
+
+
+class LayoutConfig(TypedDict):
+    """Configuration for graph layout spacing."""
+
+    horizontal_spacing: float
+    vertical_spacing: float
+    group_padding: float
 
 
 DEFAULT_CONFIG_PATH = os.path.join(
@@ -721,9 +728,8 @@ class NodzView(QtWidgets.QGraphicsView):
             self.layout_graph()
         # Enable grid snapping with 'S' (hold down)
         elif event.key() == QtCore.Qt.Key.Key_S:
-            if (
-                not event.isAutoRepeat()
-            ):  # Only on first press, not auto-repeat
+            if not event.isAutoRepeat():
+                # Only on first press, not auto-repeat
                 self._grid_snap_enabled = True
                 self._snap_selected_nodes_to_grid()
         # Delete selected nodes with Delete or Backspace
@@ -739,9 +745,8 @@ class NodzView(QtWidgets.QGraphicsView):
         """Handle key release events."""
         # Disable grid snapping when 'S' is released
         if event.key() == QtCore.Qt.Key.Key_S:
-            if (
-                not event.isAutoRepeat()
-            ):  # Only on actual release, not auto-repeat
+            if not event.isAutoRepeat():
+                # Only on actual release, not auto-repeat
                 self._grid_snap_enabled = False
         else:
             super().keyReleaseEvent(event)
@@ -926,6 +931,11 @@ class NodzView(QtWidgets.QGraphicsView):
         relationships, with root nodes (no incoming connections) on the left
         and dependent nodes arranged in subsequent columns to the right.
 
+        If node groups exist, the method will:
+        1. Layout nodes within each group as a sub-graph
+        2. Treat each group as a "super-node" and layout groups based on
+           inter-group connections
+
         Raises:
             ValueError: If the scene or configuration is invalid
         """
@@ -939,19 +949,15 @@ class NodzView(QtWidgets.QGraphicsView):
             if not name_to_views:
                 return
 
-            node_connections = self._analyze_node_connections(name_to_views)
+            # Check if there are node groups
+            group_views = self.nodz_scene.group_items()
 
-            # Find nodes that have no incoming connections (root nodes)
-            root_nodes = self._find_root_nodes(name_to_views, node_connections)
-            if not root_nodes:
-                # If no root nodes found, treat all nodes as roots (disconnected graph)
-                root_nodes = list(name_to_views.values())
-
-            # Layout each root node hierarchy
-            layout_config = self._get_layout_config()
-            self._layout_node_hierarchies(
-                root_nodes, name_to_views, node_connections, layout_config
-            )
+            if group_views:
+                # Group-aware layout
+                self._layout_graph_with_groups(name_to_views, group_views)
+            else:
+                # Standard layout without groups
+                self._layout_graph_standard(name_to_views)
 
             # Update visual elements
             self._finalize_layout()
@@ -960,6 +966,788 @@ class NodzView(QtWidgets.QGraphicsView):
             nlog.error(f"Error during graph layout: {e}")
             # Fallback: just center the graph without changing positions
             self._center_graph_in_scene()
+
+    def _layout_graph_standard(
+        self, name_to_views: Dict[str, NodeView]
+    ) -> None:
+        """
+        Perform standard hierarchical layout without groups.
+
+        Args:
+            name_to_views: Mapping of node names to NodeView objects.
+        """
+        node_connections = self._analyze_node_connections(name_to_views)
+
+        # Find nodes that have no incoming connections (root nodes)
+        root_nodes = self._find_root_nodes(name_to_views, node_connections)
+        if not root_nodes:
+            # If no root nodes found, treat all nodes as roots
+            root_nodes = list(name_to_views.values())
+
+        # Layout each root node hierarchy
+        layout_config = self._get_layout_config()
+        self._layout_node_hierarchies(
+            root_nodes, name_to_views, node_connections, layout_config
+        )
+
+    def _layout_graph_with_groups(
+        self,
+        name_to_views: Dict[str, NodeView],
+        group_views: List[NodeGroupView],
+    ) -> None:
+        """
+        Perform hierarchical layout with group awareness.
+
+        This method:
+        1. Layouts nodes within each group as sub-graphs
+        2. Treats each group as a super-node and layouts groups based on
+           inter-group connections
+        3. Handles ungrouped nodes separately
+
+        Args:
+            name_to_views: Mapping of node names to NodeView objects.
+            group_views: List of NodeGroupView items.
+        """
+        layout_config = self._get_layout_config()
+
+        # Build group membership mapping
+        group_members, ungrouped_nodes = self._categorize_nodes_by_group(
+            name_to_views, group_views
+        )
+
+        # Step 1: Layout nodes within each group as sub-graphs
+        group_dimensions = self._layout_nodes_within_groups(
+            group_members, name_to_views, layout_config
+        )
+
+        # Step 2: Analyze inter-group connections
+        inter_group_connections = self._analyze_inter_group_connections(
+            group_members, name_to_views, ungrouped_nodes
+        )
+
+        # Step 3: Layout groups as super-nodes
+        self._layout_groups_as_supernodes(
+            group_views,
+            group_dimensions,
+            inter_group_connections,
+            layout_config,
+        )
+
+        # Step 4: Layout ungrouped nodes
+        if ungrouped_nodes:
+            self._layout_ungrouped_nodes(
+                ungrouped_nodes,
+                name_to_views,
+                group_views,
+                inter_group_connections,
+                layout_config,
+            )
+
+        # Step 5: Update group rectangles to fit their members
+        self._update_group_rects_after_layout(group_views, name_to_views)
+
+    def _categorize_nodes_by_group(
+        self,
+        name_to_views: Dict[str, NodeView],
+        group_views: List[NodeGroupView],
+    ) -> tuple[Dict[str, List[str]], List[str]]:
+        """
+        Categorize nodes by their group membership.
+
+        Args:
+            name_to_views: Mapping of node names to NodeView objects.
+            group_views: List of NodeGroupView items.
+
+        Returns:
+            Tuple of (group_members dict, ungrouped_nodes list):
+            - group_members: Dict mapping group names to list of member names
+            - ungrouped_nodes: List of node names not in any group
+        """
+        group_members: Dict[str, List[str]] = {}
+        nodes_in_groups: set = set()
+
+        for group_view in group_views:
+            group_name = group_view.model.name
+            members = list(group_view.model.members)
+            # Filter to only include nodes that exist in the scene
+            valid_members = [m for m in members if m in name_to_views]
+            group_members[group_name] = valid_members
+            nodes_in_groups.update(valid_members)
+
+        ungrouped_nodes = [
+            name
+            for name in name_to_views.keys()
+            if name not in nodes_in_groups
+        ]
+
+        return group_members, ungrouped_nodes
+
+    def _layout_nodes_within_groups(
+        self,
+        group_members: Dict[str, List[str]],
+        name_to_views: Dict[str, NodeView],
+        layout_config: LayoutConfig,
+    ) -> Dict[str, Dict[str, float]]:
+        """
+        Layout nodes within each group as a sub-graph.
+
+        Each group's nodes are laid out using hierarchical logic based on
+        their internal connections. The positions are relative (starting
+        from 0,0) and will be adjusted when groups are positioned.
+
+        Args:
+            group_members: Dict mapping group names to member node names.
+            name_to_views: Mapping of node names to NodeView objects.
+            layout_config: Layout spacing configuration.
+
+        Returns:
+            Dict mapping group names to their dimensions (width, height).
+        """
+        group_dimensions: Dict[str, Dict[str, float]] = {}
+
+        for group_name, member_names in group_members.items():
+            if not member_names:
+                group_dimensions[group_name] = {
+                    "width": 100.0,
+                    "height": 100.0,
+                }
+                continue
+
+            # Build mapping for this group's nodes only
+            group_node_views = {
+                name: name_to_views[name]
+                for name in member_names
+                if name in name_to_views
+            }
+
+            if not group_node_views:
+                group_dimensions[group_name] = {
+                    "width": 100.0,
+                    "height": 100.0,
+                }
+                continue
+
+            # Analyze connections within the group only
+            internal_connections = self._analyze_internal_connections(
+                group_node_views
+            )
+
+            # Find root nodes within the group
+            root_nodes = self._find_root_nodes_in_subset(
+                group_node_views, internal_connections
+            )
+            if not root_nodes:
+                root_nodes = list(group_node_views.values())
+
+            # Layout nodes within the group starting at origin
+            self._layout_subgraph(
+                root_nodes,
+                group_node_views,
+                internal_connections,
+                layout_config,
+                start_x=0.0,
+                start_y=0.0,
+            )
+
+            # Calculate group dimensions based on positioned nodes
+            dimensions = self._calculate_group_bounds(group_node_views)
+            group_dimensions[group_name] = dimensions
+
+        return group_dimensions
+
+    def _analyze_internal_connections(
+        self, group_node_views: Dict[str, NodeView]
+    ) -> Dict[str, Dict[str, List]]:
+        """
+        Analyze connections only between nodes in a specific group.
+
+        Args:
+            group_node_views: Mapping of node names to views for group members.
+
+        Returns:
+            Connection data for internal connections only.
+        """
+        node_connections = {
+            name: {"plugs": [], "sockets": []}
+            for name in group_node_views.keys()
+        }
+
+        for item in self.nodz_scene.connection_items():
+            plug_node = item.model.plug_node
+            socket_node = item.model.socket_node
+
+            # Only include connections where both nodes are in the group
+            if (
+                plug_node in group_node_views
+                and socket_node in group_node_views
+            ):
+                node_connections[plug_node]["plugs"].append(item)
+                node_connections[socket_node]["sockets"].append(item)
+
+        return node_connections
+
+    def _find_root_nodes_in_subset(
+        self,
+        node_views: Dict[str, NodeView],
+        node_connections: Dict[str, Dict[str, List]],
+    ) -> List[NodeView]:
+        """
+        Find root nodes within a subset of nodes.
+
+        Root nodes are those with no incoming connections from within
+        the same subset.
+
+        Args:
+            node_views: Mapping of node names to NodeView objects.
+            node_connections: Connection data for the subset.
+
+        Returns:
+            List of NodeView objects that are root nodes in this subset.
+        """
+        root_nodes = [
+            node
+            for name, node in node_views.items()
+            if len(node_connections.get(name, {}).get("plugs", [])) == 0
+        ]
+        return root_nodes
+
+    def _layout_subgraph(
+        self,
+        root_nodes: List[NodeView],
+        node_views: Dict[str, NodeView],
+        node_connections: Dict[str, Dict[str, List]],
+        layout_config: LayoutConfig,
+        start_x: float,
+        start_y: float,
+    ) -> float:
+        """
+        Layout a sub-graph of nodes hierarchically.
+
+        Args:
+            root_nodes: List of root nodes to start layout from.
+            node_views: Mapping of node names to NodeView objects.
+            node_connections: Connection data for the sub-graph.
+            layout_config: Layout spacing configuration.
+            start_x: Starting X position.
+            start_y: Starting Y position.
+
+        Returns:
+            Maximum Y position used.
+        """
+        if not root_nodes:
+            return start_y
+
+        base_width = root_nodes[0].base_width if root_nodes else 100.0
+        current_y_offset = start_y
+
+        for root_node in root_nodes:
+            hierarchy_levels = self._build_node_hierarchy_subset(
+                root_node, node_views, node_connections
+            )
+
+            max_y_position = self._position_hierarchy_nodes(
+                hierarchy_levels,
+                start_x,
+                current_y_offset,
+                layout_config,
+                base_width,
+            )
+
+            current_y_offset = max_y_position
+
+        return current_y_offset
+
+    def _build_node_hierarchy_subset(
+        self,
+        root_node: NodeView,
+        node_views: Dict[str, NodeView],
+        node_connections: Dict[str, Dict[str, List]],
+    ) -> List[List[tuple]]:
+        """
+        Build hierarchy for a subset of nodes.
+
+        Similar to _build_node_hierarchy but operates on a subset.
+
+        Args:
+            root_node: The root node to start from.
+            node_views: Mapping of node names to NodeView objects.
+            node_connections: Connection data for the subset.
+
+        Returns:
+            List of levels with (node, width, height) tuples.
+        """
+        hierarchy_levels = [
+            [(root_node, root_node.base_width, root_node.height)]
+        ]
+        visited = {root_node.model.name}
+
+        current_level = 0
+        while current_level >= 0:
+            has_connections_at_level = False
+
+            for node, _, _ in hierarchy_levels[current_level]:
+                # Find connected nodes within the subset
+                connected_nodes = []
+                node_name = node.model.name
+
+                for conn in node_connections.get(node_name, {}).get(
+                    "sockets", []
+                ):
+                    source_name = conn.model.plug_node
+                    if (
+                        source_name in node_views
+                        and source_name not in visited
+                    ):
+                        connected_nodes.append(node_views[source_name])
+                        visited.add(source_name)
+
+                if connected_nodes:
+                    has_connections_at_level = True
+
+                    if len(hierarchy_levels) <= current_level + 1:
+                        hierarchy_levels.append([])
+
+                    for connected_node in connected_nodes:
+                        hierarchy_levels[current_level + 1].append(
+                            (
+                                connected_node,
+                                connected_node.base_width,
+                                connected_node.height,
+                            )
+                        )
+
+            current_level = (
+                current_level + 1 if has_connections_at_level else -1
+            )
+
+        return hierarchy_levels
+
+    def _calculate_group_bounds(
+        self, node_views: Dict[str, NodeView]
+    ) -> Dict[str, float]:
+        """
+        Calculate the bounding dimensions for a group of nodes.
+
+        Args:
+            node_views: Mapping of node names to NodeView objects.
+
+        Returns:
+            Dict with 'width' and 'height' keys.
+        """
+        if not node_views:
+            return {"width": 100.0, "height": 100.0}
+
+        min_x = min_y = float("inf")
+        max_x = max_y = float("-inf")
+
+        for node in node_views.values():
+            pos = node.pos()
+            rect = node.boundingRect()
+
+            min_x = min(min_x, pos.x())
+            min_y = min(min_y, pos.y())
+            max_x = max(max_x, pos.x() + rect.width())
+            max_y = max(max_y, pos.y() + rect.height())
+
+        width = max_x - min_x if max_x > min_x else 100.0
+        height = max_y - min_y if max_y > min_y else 100.0
+
+        return {"width": width, "height": height}
+
+    def _analyze_inter_group_connections(
+        self,
+        group_members: Dict[str, List[str]],
+        name_to_views: Dict[str, NodeView],
+        ungrouped_nodes: List[str],
+    ) -> Dict[str, Dict[str, List]]:
+        """
+        Analyze connections between groups and ungrouped nodes.
+
+        Args:
+            group_members: Dict mapping group names to member node names.
+            name_to_views: Mapping of node names to NodeView objects.
+            ungrouped_nodes: List of ungrouped node names.
+
+        Returns:
+            Dict mapping entity names (groups/ungrouped nodes) to their
+            inter-entity connections:
+            {
+                "entity_name": {
+                    "outgoing": [list of target entity names],
+                    "incoming": [list of source entity names]
+                }
+            }
+        """
+        # Build reverse lookup: node_name -> group_name (or None)
+        node_to_group: Dict[str, Optional[str]] = {}
+        for group_name, members in group_members.items():
+            for member in members:
+                node_to_group[member] = group_name
+
+        for ungrouped in ungrouped_nodes:
+            node_to_group[ungrouped] = None
+
+        # Initialize connection tracking
+        inter_connections: Dict[str, Dict[str, List]] = {}
+        for group_name in group_members.keys():
+            inter_connections[group_name] = {"outgoing": [], "incoming": []}
+        for ungrouped in ungrouped_nodes:
+            inter_connections[ungrouped] = {"outgoing": [], "incoming": []}
+
+        # Analyze all connections
+        for item in self.nodz_scene.connection_items():
+            plug_node = item.model.plug_node
+            socket_node = item.model.socket_node
+
+            source_entity = node_to_group.get(plug_node)
+            target_entity = node_to_group.get(socket_node)
+
+            # For ungrouped nodes, use the node name as entity
+            if source_entity is None:
+                source_entity = plug_node
+            if target_entity is None:
+                target_entity = socket_node
+
+            # Skip if same entity (internal connection)
+            if source_entity == target_entity:
+                continue
+
+            # Record inter-entity connection
+            if source_entity in inter_connections:
+                if (
+                    target_entity
+                    not in inter_connections[source_entity]["outgoing"]
+                ):
+                    inter_connections[source_entity]["outgoing"].append(
+                        target_entity
+                    )
+            if target_entity in inter_connections:
+                if (
+                    source_entity
+                    not in inter_connections[target_entity]["incoming"]
+                ):
+                    inter_connections[target_entity]["incoming"].append(
+                        source_entity
+                    )
+
+        return inter_connections
+
+    def _compute_hierarchy_levels(
+        self,
+        group_names: Set[str],
+        root_groups: List[NodeGroupView],
+        inter_group_connections: Dict[str, Dict[str, List]],
+        group_views: List[NodeGroupView],
+    ) -> List[List[NodeGroupView]]:
+        """
+        Compute hierarchy levels using Kahn's algorithm (topological sort).
+
+        Uses longest path algorithm to ensure each group is placed after
+        ALL its dependencies.
+
+        Args:
+            group_names: Set of all group names.
+            root_groups: List of root groups (no incoming connections).
+            inter_group_connections: Inter-group connection data.
+            group_views: All group views.
+
+        Returns:
+            List of levels, where each level contains NodeGroupView items.
+        """
+        # Each group's level = max(level of all incoming groups) + 1
+        group_levels: Dict[str, int] = {}
+
+        # Initialize root groups at level 0
+        for gv in root_groups:
+            group_levels[gv.model.name] = 0
+
+        # Calculate in-degree (from other groups only)
+        in_degree: Dict[str, int] = {gv.model.name: 0 for gv in group_views}
+        for gv in group_views:
+            group_name = gv.model.name
+            incoming = inter_group_connections.get(group_name, {}).get(
+                "incoming", []
+            )
+            incoming_from_groups = [
+                src for src in incoming if src in group_names
+            ]
+            in_degree[group_name] = len(incoming_from_groups)
+
+        # Process queue starts with root groups (in_degree == 0)
+        process_queue = [gv.model.name for gv in root_groups]
+
+        while process_queue:
+            current_name = process_queue.pop(0)
+            current_level = group_levels.get(current_name, 0)
+
+            # Get outgoing connections to other groups
+            outgoing = inter_group_connections.get(current_name, {}).get(
+                "outgoing", []
+            )
+
+            for target in outgoing:
+                if target not in group_names:
+                    continue
+
+                # Update target's level to be at least current_level + 1
+                target_current_level = group_levels.get(target, 0)
+                new_level = current_level + 1
+                if new_level > target_current_level:
+                    group_levels[target] = new_level
+
+                # Decrease in-degree and add to queue if ready
+                in_degree[target] -= 1
+                if in_degree[target] == 0:
+                    process_queue.append(target)
+
+        # Build levels list from group_levels dict
+        max_level = max(group_levels.values()) if group_levels else 0
+        levels: List[List[NodeGroupView]] = [[] for _ in range(max_level + 1)]
+
+        for gv in group_views:
+            group_name = gv.model.name
+            level = group_levels.get(group_name, 0)
+            levels[level].append(gv)
+
+        return levels
+
+    def _layout_groups_as_supernodes(
+        self,
+        group_views: List[NodeGroupView],
+        group_dimensions: Dict[str, Dict[str, float]],
+        inter_group_connections: Dict[str, Dict[str, List]],
+        layout_config: LayoutConfig,
+    ) -> None:
+        """
+        Layout groups as super-nodes based on inter-group connections.
+
+        Groups are positioned hierarchically based on their connections
+        to other groups.
+
+        Args:
+            group_views: List of NodeGroupView items.
+            group_dimensions: Dict of group dimensions (width, height).
+            inter_group_connections: Inter-group connection data.
+            layout_config: Layout spacing configuration.
+        """
+        if not group_views:
+            return
+
+        # Find root groups (data sources with no incoming connections from
+        # other groups). This is opposite of standard node layout which starts
+        # from sinks - for groups we show data flow left-to-right.
+        group_names = {gv.model.name for gv in group_views}
+        root_groups = []
+
+        for gv in group_views:
+            group_name = gv.model.name
+            incoming = inter_group_connections.get(group_name, {}).get(
+                "incoming", []
+            )
+            incoming_from_groups = [
+                src for src in incoming if src in group_names
+            ]
+            if not incoming_from_groups:
+                root_groups.append(gv)
+
+        if not root_groups:
+            root_groups = group_views.copy()
+
+        nlog.debug(f"Root groups: {[g.model.name for g in root_groups]}")
+
+        # Layout groups hierarchically
+        horizontal_spacing = layout_config["horizontal_spacing"]
+        vertical_spacing = layout_config["vertical_spacing"]
+        group_padding = layout_config["group_padding"]
+
+        # Compute hierarchy levels using topological sort
+        levels = self._compute_hierarchy_levels(
+            group_names, root_groups, inter_group_connections, group_views
+        )
+
+        positioned_groups: Set[str] = set()
+
+        # Position groups level by level
+        current_x = horizontal_spacing
+
+        for level_groups in levels:
+            # First pass: calculate max width in this level for right-alignment
+            max_width_in_level = 0.0
+            for gv in level_groups:
+                group_name = gv.model.name
+                dims = group_dimensions.get(
+                    group_name, {"width": 100.0, "height": 100.0}
+                )
+                max_width_in_level = max(max_width_in_level, dims["width"])
+
+            # Second pass: position groups right-aligned within the column
+            current_y = vertical_spacing
+
+            for gv in level_groups:
+                if gv.model.name in positioned_groups:
+                    continue
+
+                group_name = gv.model.name
+                dims = group_dimensions.get(
+                    group_name, {"width": 100.0, "height": 100.0}
+                )
+
+                # Right-align: offset by (max_width - group_width)
+                right_align_offset = max_width_in_level - dims["width"]
+                group_x = current_x + right_align_offset
+
+                # Move all member nodes by the offset from origin
+                self._move_group_members_to_position(gv, group_x, current_y)
+
+                positioned_groups.add(group_name)
+                current_y += dims["height"] + group_padding + vertical_spacing
+
+            # Move to next column
+            current_x += (
+                max_width_in_level + group_padding + horizontal_spacing
+            )
+
+    def _move_group_members_to_position(
+        self,
+        group_view: NodeGroupView,
+        target_x: float,
+        target_y: float,
+    ) -> None:
+        """
+        Move all members of a group so the group starts at target position.
+
+        Args:
+            group_view: The NodeGroupView to move.
+            target_x: Target X position for the group.
+            target_y: Target Y position for the group.
+        """
+        members = group_view.model.members
+        if not members:
+            return
+
+        # Find the current bounding box of group members
+        min_x = min_y = float("inf")
+
+        for member_name in members:
+            node_view = self._find_node_view_by_name(member_name)
+            if node_view:
+                pos = node_view.pos()
+                min_x = min(min_x, pos.x())
+                min_y = min(min_y, pos.y())
+
+        if min_x == float("inf"):
+            return
+
+        # Calculate offset needed
+        offset_x = target_x - min_x
+        offset_y = target_y - min_y
+
+        # Move all member nodes
+        for member_name in members:
+            node_view = self._find_node_view_by_name(member_name)
+            if node_view:
+                old_pos = node_view.pos()
+                new_pos = QtCore.QPointF(
+                    old_pos.x() + offset_x, old_pos.y() + offset_y
+                )
+                node_view.setPos(new_pos)
+                self.api.signals.node_moved.emit(member_name, new_pos)
+
+    def _find_node_view_by_name(self, name: str) -> Optional[NodeView]:
+        """
+        Find a NodeView by its model name.
+
+        Args:
+            name: The node name to search for.
+
+        Returns:
+            The NodeView if found, None otherwise.
+        """
+        for node_view in self.nodz_scene.node_items():
+            if node_view.model.name == name:
+                return node_view
+        return None
+
+    def _layout_ungrouped_nodes(
+        self,
+        ungrouped_nodes: List[str],
+        name_to_views: Dict[str, NodeView],
+        group_views: List[NodeGroupView],
+        inter_connections: Dict[str, Dict[str, List]],
+        layout_config: LayoutConfig,
+    ) -> None:
+        """
+        Layout ungrouped nodes based on their connections to groups.
+
+        Args:
+            ungrouped_nodes: List of ungrouped node names.
+            name_to_views: Mapping of node names to NodeView objects.
+            group_views: List of NodeGroupView items.
+            inter_connections: Inter-entity connection data.
+            layout_config: Layout spacing configuration.
+        """
+        if not ungrouped_nodes:
+            return
+
+        horizontal_spacing = layout_config["horizontal_spacing"]
+        vertical_spacing = layout_config["vertical_spacing"]
+
+        # Find the rightmost edge of all groups
+        max_group_x = 0.0
+        for gv in group_views:
+            for member_name in gv.model.members:
+                node_view = self._find_node_view_by_name(member_name)
+                if node_view:
+                    pos = node_view.pos()
+                    rect = node_view.boundingRect()
+                    max_group_x = max(max_group_x, pos.x() + rect.width())
+
+        # Build subset mapping for ungrouped nodes
+        ungrouped_views = {
+            name: name_to_views[name]
+            for name in ungrouped_nodes
+            if name in name_to_views
+        }
+
+        # Analyze connections only among ungrouped nodes
+        ungrouped_connections = self._analyze_internal_connections(
+            ungrouped_views
+        )
+
+        # Find root nodes among ungrouped
+        root_nodes = self._find_root_nodes_in_subset(
+            ungrouped_views, ungrouped_connections
+        )
+        if not root_nodes:
+            root_nodes = list(ungrouped_views.values())
+
+        # Position ungrouped nodes to the right of groups
+        start_x = max_group_x + horizontal_spacing * 2
+        start_y = vertical_spacing
+
+        self._layout_subgraph(
+            root_nodes,
+            ungrouped_views,
+            ungrouped_connections,
+            layout_config,
+            start_x,
+            start_y,
+        )
+
+    def _update_group_rects_after_layout(
+        self,
+        group_views: List[NodeGroupView],
+        name_to_views: Dict[str, NodeView],
+    ) -> None:
+        """
+        Update group rectangles to fit their member nodes after layout.
+
+        Args:
+            group_views: List of NodeGroupView items.
+            name_to_views: Mapping of node names to NodeView objects.
+        """
+        for group_view in group_views:
+            group_view.update_rect_from_members(name_to_views)
 
     def _get_all_node_views(self) -> List[NodeView]:
         """Get all NodeView items from the scene."""
@@ -1058,40 +1846,41 @@ class NodzView(QtWidgets.QGraphicsView):
         Returns:
             List of NodeView objects that are root nodes
         """
-        root_nodes = [
-            node
-            for name, node in name_to_views.items()
-            if len(node_connections[name]["plugs"]) == 0
-        ]
-        return root_nodes
+        return self._find_root_nodes_in_subset(name_to_views, node_connections)
 
-    def _get_layout_config(self) -> Dict[str, float]:
+    def _get_layout_config(self) -> LayoutConfig:
         """
         Get layout configuration values with fallback defaults.
 
         Returns:
-            Dictionary with horizontal_spacing and vertical_spacing values
+            LayoutConfig with spacing values for graph layout.
         """
         try:
             horizontal_spacing = self.config.get(
                 "horizontal_node_spacing", 80.0
             )
             vertical_spacing = self.config.get("vertical_node_spacing", 40.0)
+            group_padding = self.config.get("group_padding", 50.0)
 
-            return {
-                "horizontal_spacing": float(horizontal_spacing),
-                "vertical_spacing": float(vertical_spacing),
-            }
+            return LayoutConfig(
+                horizontal_spacing=float(horizontal_spacing),
+                vertical_spacing=float(vertical_spacing),
+                group_padding=float(group_padding),
+            )
         except (KeyError, TypeError, ValueError) as e:
             nlog.warning(f"Error reading layout config: {e}, using defaults")
-            return {"horizontal_spacing": 80.0, "vertical_spacing": 40.0}
+            return LayoutConfig(
+                horizontal_spacing=80.0,
+                vertical_spacing=40.0,
+                group_padding=50.0,
+            )
 
     def _layout_node_hierarchies(
         self,
         root_nodes: List[NodeView],
         name_to_views: Dict[str, NodeView],
         node_connections: Dict[str, Dict[str, List]],
-        layout_config: Dict[str, float],
+        layout_config: LayoutConfig,
     ) -> None:
         """
         Layout each root node hierarchy separately.
@@ -1233,7 +2022,7 @@ class NodzView(QtWidgets.QGraphicsView):
         hierarchy_levels: List[List[tuple]],
         start_x: float,
         start_y: float,
-        layout_config: Dict[str, float],
+        layout_config: LayoutConfig,
         base_node_width: float,
     ) -> float:
         """


### PR DESCRIPTION
## Changelog Description

Add support for laying out nodes while respecting group boundaries. When node groups exist, the layout algorithm:

1. Layouts nodes within each group as independent sub-graphs
2. Treats each group as a "super-node" and positions groups based on inter-group connections using topological sort
3. Handles ungrouped nodes separately, positioning them after groups
4. Updates group rectangles to fit their members after layout

Introduces LayoutConfig TypedDict for type-safe layout configuration and adds group_padding config option for spacing between groups.

## Additional review information

None

## Testing notes:
1. test with different graph topologies.
